### PR TITLE
Added defines and QSlider Tooltips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+XprotolabInterface.pro.user

--- a/XprotolabInterface.pro
+++ b/XprotolabInterface.pro
@@ -11,7 +11,8 @@ SOURCES += main.cpp\
     complex.cpp \
     customtheme.cpp \
     serialportconnection.cpp \
-    customcolors.cpp
+    customcolors.cpp \
+    qtooltipslider.cpp
 
 HEADERS  += xprotolabinterface.h \
     qcustomplot.h \
@@ -23,7 +24,8 @@ HEADERS  += xprotolabinterface.h \
     sniffer.h \
     customtheme.h \
     serialportconnection.h \
-    customcolors.h
+    customcolors.h \
+    qtooltipslider.h
 
 FORMS += xprotolabinterface.ui \
     customtheme.ui

--- a/qtooltipslider.cpp
+++ b/qtooltipslider.cpp
@@ -1,0 +1,24 @@
+#include "qtooltipslider.h"
+
+QToolTipSlider::QToolTipSlider(QWidget * parent):QSlider(parent)
+{
+    this->setValueToolTip(this->value());
+    connect(this, SIGNAL(valueChanged(int)), this, SLOT(setValueToolTip(int)));
+}
+
+QToolTipSlider::QToolTipSlider(Qt::Orientation orientation, QWidget * parent):QSlider(orientation, parent)
+{
+    this->setValueToolTip(this->value());
+    connect(this, SIGNAL(valueChanged(int)), this, SLOT(setValueToolTip(int)));
+}
+
+QToolTipSlider::~QToolTipSlider()
+{
+
+}
+
+void QToolTipSlider::setValueToolTip(int value)
+{
+    this->setToolTip(QString::number(value));
+    this->repaint();
+}

--- a/qtooltipslider.h
+++ b/qtooltipslider.h
@@ -1,0 +1,19 @@
+#ifndef QTOOLTIPSLIDER_H
+#define QTOOLTIPSLIDER_H
+
+#include <QSlider>
+
+class QToolTipSlider : public QSlider
+{
+    Q_OBJECT
+
+public:
+    QToolTipSlider(QWidget * parent = 0);
+    QToolTipSlider(Qt::Orientation orientation, QWidget * parent = 0);
+    ~QToolTipSlider();
+
+public slots:
+    void setValueToolTip(int value);
+};
+
+#endif // QTOOLTIPSLIDER_H

--- a/xprotolabinterface.cpp
+++ b/xprotolabinterface.cpp
@@ -761,7 +761,7 @@ int XprotolabInterface::checkValue(int value, int min, int max){
 
 void XprotolabInterface::plotData()
 {
-    if(ui->mainTabWidget->currentIndex() == 1){
+    if(ui->mainTabWidget->currentIndex() == METER_TAB){
         ui->plotterWidget->clearScene();
     }
 
@@ -889,7 +889,7 @@ void XprotolabInterface::plotData()
             }
         }
     }
-    if(ui->mainTabWidget->currentIndex() == 1)
+    if(ui->mainTabWidget->currentIndex() == METER_TAB)
         mm_request();
     if(ui->radioButtonCursorCH1->isChecked())
     {
@@ -1454,7 +1454,7 @@ void XprotolabInterface::plotData()
     ch2ZeroHead->topLeft->setPixelPoint(QPointF(2,ui->plotterWidget->yAxis->coordToPixel(ch2ZeroPos)));
 
     ui->plotterWidget->m_infinity = ui->checkBoxPersistence->isChecked();
-    if(ui->mainTabWidget->currentIndex() != 1)
+    if(ui->mainTabWidget->currentIndex() != METER_TAB)
         ui->plotterWidget->replot();
 
     usbDevice.dataAvailable = false;
@@ -1954,7 +1954,7 @@ void XprotolabInterface::sniffProtocol()
             ui->misoTextEdit->setPlainText(txData);
 
     }
-    else if(ui->protocolTabWidget->currentIndex()==I2C)
+    else if(protocol == I2C)
     {
 
         i = 0;j = 0;
@@ -2505,7 +2505,7 @@ void XprotolabInterface::readDeviceSettings()
     else
        ui->stopButton->setText(tr("START"));
 
-    if(ui->mainTabWidget->currentIndex() == 1){
+    if(ui->mainTabWidget->currentIndex() == METER_TAB){
         if((data & (byte)(1 << 6)) == 0 && (data & (byte)(1 << 7)) == 0) {
             ui->mmTabWidget->setCurrentIndex(2);
         } else{
@@ -3562,7 +3562,7 @@ void XprotolabInterface::sendMStatusControlsForMM()
 {
     byte field = 1; // Set the update bit
     if(ui->mmTabWidget->currentIndex() == 0)      field += (1 << 6);
-    else if(ui->mmTabWidget->currentIndex() == 1) field += (1 << 7);
+    else if(ui->mmTabWidget->currentIndex() == VDC_TAB) field += (1 << 7);
     else if(ui->radioPulse->isChecked()) field += (1 << 6) + (1 << 7);
     usbDevice.controlWriteTransfer(11, field);
 }
@@ -3771,6 +3771,8 @@ void XprotolabInterface::on_doubleSpinBoxTrigAuto_valueChanged(double value)
 // M 29 Channel 1 position
 void XprotolabInterface::on_ch1PositionSlider_valueChanged(int value)
 {
+    ui->ch1PositionSlider->setToolTip(QString::number(ui->ch1PositionSlider->value()));
+
     usbDevice.controlWriteTransfer(29, mapRange(value,128,-128,0,-128));
     double tmp_pos = ch1ZeroPos;
     ch1ZeroPos = rangeMax/2+ui->ch1PositionSlider->value();
@@ -4801,10 +4803,10 @@ void XprotolabInterface::on_mainTabWidget_currentChanged(int index)
         prepareMFFTControlsForMM();
         sendMStatusControlsForMM();
         connect(&m_mmTimer,SIGNAL(timeout()),this,SLOT(mm_request()));
-        if(ui->mmTabWidget->currentIndex() == 2){
+        if(ui->mmTabWidget->currentIndex() == FREQ_TAB){
             sendTSource();
             m_mmTimer.start(1000);
-        }else if(ui->mmTabWidget->currentIndex() == 0){
+        }else if(ui->mmTabWidget->currentIndex() == VPP_TAB){
             m_mmTimer.start(250);
         }
         clearMMLabels();
@@ -4825,7 +4827,7 @@ void XprotolabInterface::restoreUiSettings(){
     on_ch1GainSlider_valueChanged(ui->ch1GainSlider->value());
     on_ch2GainSlider_valueChanged(ui->ch2GainSlider->value());
     on_samplingSlider_valueChanged(ui->samplingSlider->value());
-    if(ui->mmTabWidget->currentIndex() != 1)
+    if(ui->mmTabWidget->currentIndex() != VDC_TAB)
         usbDevice.turnOnAutoMode();
 }
 
@@ -4840,11 +4842,11 @@ void XprotolabInterface::clearMMLabels(){
 
 void XprotolabInterface::mm_request(){
     unsigned char tmp_buff[] = {0, 0, 0, 0};
-    if(ui->mmTabWidget->currentIndex() != 1){
+    if(ui->mmTabWidget->currentIndex() != VDC_TAB){
         int size = usbDevice.requestMM(tmp_buff);
         if(size != 4) return;
     }
-    if(ui->mmTabWidget->currentIndex() == 0) {
+    if(ui->mmTabWidget->currentIndex() == VPP_TAB) {
         double ch1, ch2;
         QString sign1 = " ", sign2 = " ";
         if((int)tmp_buff[1] >= 100){
@@ -4880,7 +4882,7 @@ void XprotolabInterface::mm_request(){
         tmp_v2 += get4Digits(ch2);
         tmp_v2 += "V";
         ui->vdcChannel2->setText(tmp_v2);
-    } else if(ui->mmTabWidget->currentIndex() == 1) {
+    } else if(ui->mmTabWidget->currentIndex() == VDC_TAB) {
         double tmp_diff1 = (vppMaxCh1 - vppMinCh1) / 100.0;
         QString sign1 = " ";
         if(tmp_diff1 < 0) sign1 = "";
@@ -4927,11 +4929,11 @@ void XprotolabInterface::on_mmTabWidget_currentChanged(int)
     ui->radioFreq->setChecked(true);
     ui->radioPulse->setChecked(false);
 
-    if(ui->mmTabWidget->currentIndex() == 2) {
+    if(ui->mmTabWidget->currentIndex() == FREQ_TAB) {
         sendTSource();
         if(ui->radioPulse->isChecked()) m_mmTimer.start(100);
         else m_mmTimer.start(1000);
-    } else if(ui->mmTabWidget->currentIndex() == 0) {
+    } else if(ui->mmTabWidget->currentIndex() == VPP_TAB) {
         m_mmTimer.start(250);
     } else {
         usbDevice.turnOnAutoMode();

--- a/xprotolabinterface.h
+++ b/xprotolabinterface.h
@@ -36,6 +36,7 @@
 #include <QSettings>
 #include "customtheme.h"
 #include "qcustomplot.h"
+#include "qtooltipslider.h"
 #include "libusbdevice.h"
 #include "fft.h"
 #include "sniffer.h"
@@ -99,6 +100,36 @@ enum Theme {
     Light,
     Custom
 };
+
+enum MainTabs {
+    SCOPE_TAB,
+    METER_TAB,
+    AWG_TAB,
+    SNIFFER_TAB,
+    OPTIONS_TAB,
+    ABOUT_TAB
+};
+
+enum ScopeTabs {
+    CH1_TAB,
+    CH2_TAB,
+    LOGIC_TAB,
+    FFT_TAB,
+    REF_TAB
+};
+
+enum MeterTabs {
+    VPP_TAB,
+    VDC_TAB,
+    FREQ_TAB
+};
+
+enum SnifferTabs {
+    SPI_TAB,
+    I2C_TAB,
+    RS232_TAB
+};
+
 #define TG 9
 
 typedef QVector<double> DataBuffer;

--- a/xprotolabinterface.ui
+++ b/xprotolabinterface.ui
@@ -324,7 +324,7 @@
                    </widget>
                   </item>
                   <item>
-                   <widget class="QSlider" name="samplingSlider">
+                   <widget class="QToolTipSlider" name="samplingSlider">
                     <property name="maximum">
                      <number>21</number>
                     </property>
@@ -350,7 +350,7 @@
                      <bool>false</bool>
                     </property>
                     <property name="tickPosition">
-                     <enum>QSlider::TicksBelow</enum>
+                     <enum>QToolTipSlider::TicksBelow</enum>
                     </property>
                     <property name="tickInterval">
                      <number>1</number>
@@ -501,7 +501,7 @@
                            </spacer>
                           </item>
                           <item>
-                           <widget class="QSlider" name="ch1PositionSlider">
+                           <widget class="QToolTipSlider" name="ch1PositionSlider">
                             <property name="minimum">
                              <number>-128</number>
                             </property>
@@ -530,7 +530,7 @@
                              <bool>false</bool>
                             </property>
                             <property name="tickPosition">
-                             <enum>QSlider::TicksBelow</enum>
+                             <enum>QToolTipSlider::TicksBelow</enum>
                             </property>
                             <property name="tickInterval">
                              <number>16</number>
@@ -592,7 +592,7 @@
                                </spacer>
                               </item>
                               <item>
-                               <widget class="QSlider" name="ch1GainSlider">
+                               <widget class="QToolTipSlider" name="ch1GainSlider">
                                 <property name="maximum">
                                  <number>6</number>
                                 </property>
@@ -612,7 +612,7 @@
                                  <enum>Qt::Vertical</enum>
                                 </property>
                                 <property name="tickPosition">
-                                 <enum>QSlider::TicksBelow</enum>
+                                 <enum>QToolTipSlider::TicksBelow</enum>
                                 </property>
                                 <property name="tickInterval">
                                  <number>1</number>
@@ -825,7 +825,7 @@
                            </spacer>
                           </item>
                           <item>
-                           <widget class="QSlider" name="ch2PositionSlider">
+                           <widget class="QToolTipSlider" name="ch2PositionSlider">
                             <property name="minimum">
                              <number>-128</number>
                             </property>
@@ -854,7 +854,7 @@
                              <bool>false</bool>
                             </property>
                             <property name="tickPosition">
-                             <enum>QSlider::TicksBelow</enum>
+                             <enum>QToolTipSlider::TicksBelow</enum>
                             </property>
                             <property name="tickInterval">
                              <number>16</number>
@@ -916,7 +916,7 @@
                                </spacer>
                               </item>
                               <item>
-                               <widget class="QSlider" name="ch2GainSlider">
+                               <widget class="QToolTipSlider" name="ch2GainSlider">
                                 <property name="maximum">
                                  <number>6</number>
                                 </property>
@@ -936,7 +936,7 @@
                                  <enum>Qt::Vertical</enum>
                                 </property>
                                 <property name="tickPosition">
-                                 <enum>QSlider::TicksBelow</enum>
+                                 <enum>QToolTipSlider::TicksBelow</enum>
                                 </property>
                                 <property name="tickInterval">
                                  <number>1</number>
@@ -1151,7 +1151,7 @@
                              </spacer>
                             </item>
                             <item>
-                             <widget class="QSlider" name="chdPositionSlider">
+                             <widget class="QToolTipSlider" name="chdPositionSlider">
                               <property name="minimum">
                                <number>0</number>
                               </property>
@@ -1174,7 +1174,7 @@
                                <enum>Qt::Vertical</enum>
                               </property>
                               <property name="tickPosition">
-                               <enum>QSlider::TicksBelow</enum>
+                               <enum>QToolTipSlider::TicksBelow</enum>
                               </property>
                               <property name="tickInterval">
                                <number>1</number>
@@ -1232,7 +1232,7 @@
                              </spacer>
                             </item>
                             <item>
-                             <widget class="QSlider" name="chdSizeSlider">
+                             <widget class="QToolTipSlider" name="chdSizeSlider">
                               <property name="minimum">
                                <number>0</number>
                               </property>
@@ -1246,7 +1246,7 @@
                                <enum>Qt::Vertical</enum>
                               </property>
                               <property name="tickPosition">
-                               <enum>QSlider::TicksBelow</enum>
+                               <enum>QToolTipSlider::TicksBelow</enum>
                               </property>
                               <property name="tickInterval">
                                <number>10</number>
@@ -1349,7 +1349,7 @@
                            </layout>
                           </item>
                           <item>
-                           <widget class="QSlider" name="chdPullSlider">
+                           <widget class="QToolTipSlider" name="chdPullSlider">
                             <property name="minimum">
                              <number>0</number>
                             </property>
@@ -1366,7 +1366,7 @@
                              <enum>Qt::Vertical</enum>
                             </property>
                             <property name="tickPosition">
-                             <enum>QSlider::TicksBelow</enum>
+                             <enum>QToolTipSlider::TicksBelow</enum>
                             </property>
                             <property name="tickInterval">
                              <number>1</number>
@@ -1615,7 +1615,7 @@
                            </spacer>
                           </item>
                           <item>
-                           <widget class="QSlider" name="verticalSlider_8">
+                           <widget class="QToolTipSlider" name="fftPositionSlider">
                             <property name="singleStep">
                              <number>10</number>
                             </property>
@@ -1626,7 +1626,7 @@
                              <enum>Qt::Vertical</enum>
                             </property>
                             <property name="tickPosition">
-                             <enum>QSlider::TicksBelow</enum>
+                             <enum>QToolTipSlider::TicksBelow</enum>
                             </property>
                            </widget>
                           </item>
@@ -1789,7 +1789,7 @@
                            </spacer>
                           </item>
                           <item>
-                           <widget class="QSlider" name="ch1CaptureSlider">
+                           <widget class="QToolTipSlider" name="ch1CaptureSlider">
                             <property name="minimum">
                              <number>-128</number>
                             </property>
@@ -1809,7 +1809,7 @@
                              <enum>Qt::Vertical</enum>
                             </property>
                             <property name="tickPosition">
-                             <enum>QSlider::TicksBelow</enum>
+                             <enum>QToolTipSlider::TicksBelow</enum>
                             </property>
                             <property name="tickInterval">
                              <number>16</number>
@@ -1847,7 +1847,7 @@
                            </spacer>
                           </item>
                           <item>
-                           <widget class="QSlider" name="ch2CaptureSlider">
+                           <widget class="QToolTipSlider" name="ch2CaptureSlider">
                             <property name="minimum">
                              <number>-128</number>
                             </property>
@@ -1870,7 +1870,7 @@
                              <enum>Qt::Vertical</enum>
                             </property>
                             <property name="tickPosition">
-                             <enum>QSlider::TicksBelow</enum>
+                             <enum>QToolTipSlider::TicksBelow</enum>
                             </property>
                             <property name="tickInterval">
                              <number>16</number>
@@ -1908,7 +1908,7 @@
                            </spacer>
                           </item>
                           <item>
-                           <widget class="QSlider" name="chdCaptureSlider">
+                           <widget class="QToolTipSlider" name="chdCaptureSlider">
                             <property name="minimum">
                              <number>-128</number>
                             </property>
@@ -1928,7 +1928,7 @@
                              <enum>Qt::Vertical</enum>
                             </property>
                             <property name="tickPosition">
-                             <enum>QSlider::TicksBelow</enum>
+                             <enum>QToolTipSlider::TicksBelow</enum>
                             </property>
                             <property name="tickInterval">
                              <number>16</number>
@@ -3337,7 +3337,7 @@
                  </layout>
                 </item>
                 <item>
-                 <widget class="QSlider" name="frequencySlider">
+                 <widget class="QToolTipSlider" name="frequencySlider">
                   <property name="minimum">
                    <number>10</number>
                   </property>
@@ -3351,7 +3351,7 @@
                    <enum>Qt::Horizontal</enum>
                   </property>
                   <property name="tickPosition">
-                   <enum>QSlider::NoTicks</enum>
+                   <enum>QToolTipSlider::NoTicks</enum>
                   </property>
                   <property name="tickInterval">
                    <number>10</number>
@@ -3510,7 +3510,7 @@ Frequency</string>
                 </widget>
                </item>
                <item>
-                <widget class="QSlider" name="amplitudeSlider">
+                <widget class="QToolTipSlider" name="amplitudeSlider">
                  <property name="maximum">
                   <number>128</number>
                  </property>
@@ -3527,7 +3527,7 @@ Frequency</string>
                   <enum>Qt::Horizontal</enum>
                  </property>
                  <property name="tickPosition">
-                  <enum>QSlider::NoTicks</enum>
+                  <enum>QToolTipSlider::NoTicks</enum>
                  </property>
                  <property name="tickInterval">
                   <number>16</number>
@@ -3568,7 +3568,7 @@ Frequency</string>
                 </widget>
                </item>
                <item>
-                <widget class="QSlider" name="dutyCycleSlider">
+                <widget class="QToolTipSlider" name="dutyCycleSlider">
                  <property name="minimum">
                   <number>1</number>
                  </property>
@@ -3644,7 +3644,7 @@ Frequency</string>
                 </widget>
                </item>
                <item>
-                <widget class="QSlider" name="offsetSlider">
+                <widget class="QToolTipSlider" name="offsetSlider">
                  <property name="minimum">
                   <number>-127</number>
                  </property>
@@ -3784,7 +3784,7 @@ Frequency</string>
                      </layout>
                     </item>
                     <item>
-                     <widget class="QSlider" name="sweepSpeedSlider">
+                     <widget class="QToolTipSlider" name="sweepSpeedSlider">
                       <property name="toolTip">
                        <string>Sweep speed</string>
                       </property>
@@ -3807,7 +3807,7 @@ Frequency</string>
                        <enum>Qt::Horizontal</enum>
                       </property>
                       <property name="tickPosition">
-                       <enum>QSlider::NoTicks</enum>
+                       <enum>QToolTipSlider::NoTicks</enum>
                       </property>
                       <property name="tickInterval">
                        <number>16</number>
@@ -3838,7 +3838,7 @@ Frequency</string>
                        </widget>
                       </item>
                       <item>
-                       <widget class="QSlider" name="sweepStartFreqSlider">
+                       <widget class="QToolTipSlider" name="sweepStartFreqSlider">
                         <property name="toolTip">
                          <string>Sweep start frequency</string>
                         </property>
@@ -3858,7 +3858,7 @@ Frequency</string>
                          <enum>Qt::Horizontal</enum>
                         </property>
                         <property name="tickPosition">
-                         <enum>QSlider::NoTicks</enum>
+                         <enum>QToolTipSlider::NoTicks</enum>
                         </property>
                         <property name="tickInterval">
                          <number>16</number>
@@ -3887,7 +3887,7 @@ Frequency</string>
                        </widget>
                       </item>
                       <item>
-                       <widget class="QSlider" name="sweepEndFreqSlider">
+                       <widget class="QToolTipSlider" name="sweepEndFreqSlider">
                         <property name="toolTip">
                          <string>Sweep end frequency</string>
                         </property>
@@ -4701,7 +4701,7 @@ Frequency</string>
                        </widget>
                       </item>
                       <item>
-                       <widget class="QSlider" name="intensitySlider">
+                       <widget class="QToolTipSlider" name="intensitySlider">
                         <property name="minimum">
                          <number>0</number>
                         </property>
@@ -4727,7 +4727,7 @@ Frequency</string>
                          <bool>true</bool>
                         </property>
                         <property name="tickPosition">
-                         <enum>QSlider::TicksBelow</enum>
+                         <enum>QToolTipSlider::TicksBelow</enum>
                         </property>
                         <property name="tickInterval">
                          <number>1</number>
@@ -4785,7 +4785,7 @@ Frequency</string>
                        </widget>
                       </item>
                       <item>
-                       <widget class="QSlider" name="decaySlider">
+                       <widget class="QToolTipSlider" name="decaySlider">
                         <property name="maximum">
                          <number>8</number>
                         </property>
@@ -4796,7 +4796,7 @@ Frequency</string>
                          <enum>Qt::Horizontal</enum>
                         </property>
                         <property name="tickPosition">
-                         <enum>QSlider::TicksBelow</enum>
+                         <enum>QToolTipSlider::TicksBelow</enum>
                         </property>
                         <property name="tickInterval">
                          <number>1</number>
@@ -5688,6 +5688,12 @@ background-position: center;</string>
    <class>QCustomPlot</class>
    <extends>QWidget</extends>
    <header>qcustomplot.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QToolTipSlider</class>
+   <extends>QSlider</extends>
+   <header>qtooltipslider.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
I've added enums for all the tabs and subtabs so that the tabs can be referenced by constants instead of numerical literals.  Since most of the tabs aren't referenced directly, several of the enums may be superfluous.  I've also created a new type of slider that displays the current value in the tooltip and updated all sliders to be this type to give a way to view the exact value.