### PR TITLE
libusbdevice: Init class members

### DIFF
--- a/libusbdevice.cpp
+++ b/libusbdevice.cpp
@@ -15,6 +15,8 @@ LibUsbDevice::LibUsbDevice(QObject *parent) :
     pcToUsbDeviceTransfer = NULL;
     usbDeviceToPcTransfer = NULL;
     dataAvailable = false;
+    count = 0;
+    dataLength = 0;
     hasHotPlugSupport = false;
     deviceFound = NULL;
     connect(&serial,SIGNAL(newData(int)),this,SLOT(newDataAvailable(int)));


### PR DESCRIPTION
This will prevent segfault in:
XprotolabInterface::sniffProtocol

Change-Id: Ifb80c83c75a495c3eaf2a2392919100ec8ea5f13
Origin: https://github.com/rzr/xscopes-qt/
Signed-off-by: Philippe Coval <rzr@users.sf.net>