### PR TITLE
show serial interfaces in current macOS versions

### DIFF
--- a/xprotolabinterface.cpp
+++ b/xprotolabinterface.cpp
@@ -175,8 +175,8 @@ void XprotolabInterface::checkForAvailableComPorts(){
 bool XprotolabInterface::checkIfCorrectPort(QString name){
     #ifdef Q_OS_WIN
         return name.toLower().startsWith("com");
-    #elif defined(Q_OS_MAC)
-        return name.toLower().startsWith("bluetooth");
+//     #elif defined(Q_OS_MAC)
+//         return name.toLower().startsWith("bluetooth");
     #else
         return name.toLower().startsWith("tty");
     #endif


### PR DESCRIPTION
With Sierra and highSierra the serial ports in macOS have been named
cu.something and tty.something.  So for each port there are two
variants. This also applies to bluetooth ports

Could this be changed in the code so serial ports gets shown in macOS
again?