### PR TITLE
build: Add local lib path for darwin and windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,12 @@ pkg_check_modules(LIBUSB REQUIRED libusb-1.0)
 include_directories(${LIBUSB_INCLUDE_DIRS})
 link_directories(${LIBUSB_LIBRARY_DIRS})
 
+if(UNIX AND APPLE)
+link_directories(libs/mac)
+elif(WIN32)
+link_directories(libs/win)
+endif()
+
 #message(status "LIBUSB_INCLUDE_DIRS" ${LIBUSB_INCLUDE_DIRS} "LANGUAGE" ${LANGUAGE})
 
 if( CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX )

--- a/XprotolabInterface.pro
+++ b/XprotolabInterface.pro
@@ -42,7 +42,7 @@ win32: LIBS += -L$$PWD/libs/win -llibusb-1.0
 
 macx: LIBS += $$PWD/libs/mac/libusb-1.0.dylib
 
-unix: LIBS += -L$$PWD/libs/unix -lusb-1.0
+unix:!macx: LIBS += -lusb-1.0
 
 RC_FILE = xprotolabinterface.rc
 


### PR DESCRIPTION
In longer term it would make sense to remove those libs
and use system's ones like linux

Change-Id: I6399b9715b245c2cc11828a0f3bb8f825f72c0c3
Bug: https://github.com/ganzziani/xscopes-qt/issues/36
Signed-off-by: Philippe Coval <rzr@users.sf.net>